### PR TITLE
fix(openclaw/init): atomic .env writes with rollback on abort (#34)

### DIFF
--- a/packages/openclaw/src/env-atomic.ts
+++ b/packages/openclaw/src/env-atomic.ts
@@ -1,0 +1,157 @@
+// ~/.keyoku/.env atomic-write helpers.
+//
+// Background: init runs through 10+ phases, each writing env keys (provider,
+// model, api keys, db path, quiet hours…). The old implementation wrote to
+// disk per-key, so if the user aborted mid-flow (or a phase errored) the
+// file was left in a half-applied state — e.g. provider switched to Gemini
+// with no GEMINI_API_KEY, which then bricks keyoku-engine boot. See
+// keyoku#34 and harness/20-contracts/config.md §Atomicity.
+//
+// Contract honored here:
+//   stage-then-commit | atomic rename | backup on replace | signal safe |
+//   credential gate.
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  cpSync,
+  renameSync,
+  unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+export interface EnvStaging {
+  /** Stage a key=value; does NOT touch disk. */
+  stage(key: string, value: string): void;
+  /** Effective value (staged → process.env fallback). */
+  effective(key: string): string | undefined;
+  /** Atomically persist staged writes. No-op when nothing is staged. */
+  commit(): void;
+  /** Drop staged writes and restore .env from .env.bak if present. */
+  rollback(): void;
+  /** Snapshot count of pending writes — for tests/diagnostics. */
+  pendingCount(): number;
+}
+
+export interface EnvStagingOptions {
+  /** Root dir that contains the .env file. Defaults to ~/.keyoku. */
+  dir: string;
+  /**
+   * If true, mirror staged writes into `process.env` so in-process callers
+   * that read env via process.env observe staged values before commit.
+   * init.ts needs this for downstream step continuity. Tests disable it.
+   */
+  mirrorProcessEnv?: boolean;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Merge staged key/values into an existing .env body. Replace-in-place
+ *  when a key already exists, otherwise append on a new line. */
+export function mergeEnvContent(base: string, staged: Map<string, string>): string {
+  let content = base;
+  for (const [key, value] of staged) {
+    const line = `${key}=${value}`;
+    const regex = new RegExp(`^${escapeRegExp(key)}=.*$`, 'm');
+    if (regex.test(content)) {
+      content = content.replace(regex, line);
+    } else {
+      if (content.length > 0 && !content.endsWith('\n')) content += '\n';
+      content += `${line}\n`;
+    }
+  }
+  return content;
+}
+
+export function createEnvStaging(opts: EnvStagingOptions): EnvStaging {
+  const envPath = join(opts.dir, '.env');
+  const tmpPath = join(opts.dir, '.env.tmp');
+  const bakPath = join(opts.dir, '.env.bak');
+  const staged: Map<string, string> = new Map();
+  let snapshot = '';
+  let snapshotLoaded = false;
+
+  const mirrorProcessEnv = opts.mirrorProcessEnv ?? true;
+
+  function loadSnapshot(): void {
+    if (snapshotLoaded) return;
+    snapshot = existsSync(envPath) ? readFileSync(envPath, 'utf-8') : '';
+    snapshotLoaded = true;
+  }
+
+  return {
+    stage(key, value) {
+      loadSnapshot();
+      staged.set(key, value);
+      if (mirrorProcessEnv) process.env[key] = value;
+    },
+    effective(key) {
+      return staged.get(key) ?? process.env[key];
+    },
+    commit() {
+      if (staged.size === 0) return;
+      loadSnapshot();
+      mkdirSync(opts.dir, { recursive: true });
+      const merged = mergeEnvContent(snapshot, staged);
+      if (existsSync(envPath)) {
+        cpSync(envPath, bakPath);
+      }
+      writeFileSync(tmpPath, merged, 'utf-8');
+      renameSync(tmpPath, envPath);
+      snapshot = merged;
+      staged.clear();
+    },
+    rollback() {
+      staged.clear();
+      try {
+        if (existsSync(tmpPath)) unlinkSync(tmpPath);
+      } catch {
+        // best-effort
+      }
+      if (existsSync(bakPath)) {
+        try {
+          cpSync(bakPath, envPath);
+        } catch {
+          // leave disk untouched if backup unreadable
+        }
+      }
+    },
+    pendingCount() {
+      return staged.size;
+    },
+  };
+}
+
+/**
+ * Per-provider credential requirement. Checked before commit so we never
+ * persist a provider switch the engine can't actually use.
+ */
+export const PROVIDER_REQUIRED_KEYS: Record<string, string> = {
+  openai: 'OPENAI_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  ollama: 'OLLAMA_BASE_URL',
+};
+
+export function assertProviderCredentials(
+  staging: EnvStaging,
+  ...providers: string[]
+): void {
+  const missing: string[] = [];
+  for (const provider of new Set(providers)) {
+    const required = PROVIDER_REQUIRED_KEYS[provider.toLowerCase()];
+    if (!required) continue;
+    if (!staging.effective(required)) {
+      missing.push(`${provider} requires ${required}`);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `refusing to persist provider config — missing credentials: ${missing.join(', ')}`,
+    );
+  }
+}

--- a/packages/openclaw/src/init.ts
+++ b/packages/openclaw/src/init.ts
@@ -39,6 +39,11 @@ import {
 } from './heartbeat-migration.js';
 import { findKeyokuBinary, loadKeyokuEnv, waitForHealthy } from './service.js';
 import { updateEngine } from './update-engine.js';
+import {
+  createEnvStaging,
+  assertProviderCredentials,
+  type EnvStaging,
+} from './env-atomic.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -673,7 +678,18 @@ async function setupLlmProvider(): Promise<{ embeddingProvider: string; extracti
   // Isolate vector dimensions/index state per embedding backend.
   // This avoids dimension/index corruption when switching providers/models
   // (e.g. OpenAI 1536-dim → Ollama 768-dim) on the same DB file.
-  configureProviderScopedDbPath(embeddingProvider, process.env.KEYOKU_EMBEDDING_MODEL || 'default');
+  configureProviderScopedDbPath(embeddingProvider, effectiveEnv('KEYOKU_EMBEDDING_MODEL') || 'default');
+
+  // Gate before commit: refuse to persist a provider switch that's
+  // missing its credential (keyoku#34). Throwing here rolls back via
+  // the outer try/catch in init() and leaves ~/.keyoku/.env untouched.
+  assertProviderCredentialsStaged(embeddingProvider, extractionProvider);
+
+  // Atomically persist the full provider config in one go. Downstream
+  // steps (engine compatibility check, migration temp-start) depend on
+  // these values being readable from ~/.keyoku/.env, so we commit here
+  // rather than deferring to the end of init().
+  commitEnvStaging();
 
   if (neededProviders.has('ollama')) {
     info('If startup reports "unknown provider: ollama", update engine binary:');
@@ -872,30 +888,46 @@ function configureProviderScopedDbPath(embeddingProvider: string, embeddingModel
   info(`${c.dim}Provider-scoped DB path set to avoid mixed-dimension vector indexes.${c.reset}`);
 }
 
-/**
- * Append a key=value to ~/.keyoku/.env (creates if needed).
- * This file is sourced by the service when starting keyoku-engine.
- */
+// ── Atomic env-file staging ─────────────────────────────────────────────
+// See src/env-atomic.ts and harness/20-contracts/config.md §Atomicity.
+// ~/.keyoku/.env is written transactionally: stage → validate → rename.
+
+const envStaging: EnvStaging = createEnvStaging({
+  dir: join(HOME, '.keyoku'),
+  mirrorProcessEnv: true,
+});
+let rollbackHandlerInstalled = false;
+
 function appendToEnvFile(key: string, value: string): void {
-  const envDir = join(HOME, '.keyoku');
-  const envPath = join(envDir, '.env');
-  mkdirSync(envDir, { recursive: true });
+  installRollbackHandler();
+  envStaging.stage(key, value);
+}
 
-  let content = '';
-  if (existsSync(envPath)) {
-    content = readFileSync(envPath, 'utf-8');
-    // Replace existing key if present
-    const regex = new RegExp(`^${key}=.*$`, 'm');
-    if (regex.test(content)) {
-      content = content.replace(regex, `${key}=${value}`);
-      writeFileSync(envPath, content, 'utf-8');
-      return;
-    }
-  }
+function effectiveEnv(key: string): string | undefined {
+  return envStaging.effective(key);
+}
 
-  // Append new key
-  const line = `${key}=${value}\n`;
-  writeFileSync(envPath, content + line, 'utf-8');
+function commitEnvStaging(): void {
+  envStaging.commit();
+}
+
+function rollbackEnvStaging(): void {
+  envStaging.rollback();
+}
+
+function installRollbackHandler(): void {
+  if (rollbackHandlerInstalled) return;
+  rollbackHandlerInstalled = true;
+  const onSignal = (sig: NodeJS.Signals) => {
+    rollbackEnvStaging();
+    process.exit(sig === 'SIGINT' ? 130 : 143);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+}
+
+function assertProviderCredentialsStaged(...providers: string[]): void {
+  assertProviderCredentials(envStaging, ...providers);
 }
 
 // ── System Configuration ─────────────────────────────────────────────────
@@ -1155,6 +1187,23 @@ async function healthCheck(): Promise<boolean> {
  * Main init function — orchestrates the full setup.
  */
 export async function init(): Promise<void> {
+  // Install SIGINT/SIGTERM rollback before any staged writes can accumulate.
+  // Guarantees ~/.keyoku/.env is never left in a half-applied state if the
+  // user ^C's mid-flow (keyoku#34).
+  installRollbackHandler();
+  try {
+    await runInit();
+    // Final flush for any trailing staged writes (quiet hours, timezone,
+    // autonomy). Provider config was already committed inside
+    // setupLlmProvider().
+    commitEnvStaging();
+  } catch (err) {
+    rollbackEnvStaging();
+    throw err;
+  }
+}
+
+async function runInit(): Promise<void> {
   console.log('');
   console.log(`  ${c.indigo}${c.bold}  █  █  █▀▀  █   █  █▀▀█  █  █  █  █${c.reset}`);
   console.log(`  ${c.indigo}${c.bold}  █▄▀   █▀▀   █ █   █  █  █▀▄   █  █${c.reset}`);

--- a/packages/openclaw/test/env-atomic.test.ts
+++ b/packages/openclaw/test/env-atomic.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createEnvStaging,
+  assertProviderCredentials,
+  mergeEnvContent,
+  PROVIDER_REQUIRED_KEYS,
+} from '../src/env-atomic.js';
+
+function tmpDir(): string {
+  return mkdtempSync(join(process.env.TMPDIR || '/tmp', 'keyoku-env-atomic-'));
+}
+
+describe('mergeEnvContent', () => {
+  it('appends new keys with trailing newline', () => {
+    const staged = new Map([
+      ['FOO', 'one'],
+      ['BAR', 'two'],
+    ]);
+    const out = mergeEnvContent('', staged);
+    expect(out).toBe('FOO=one\nBAR=two\n');
+  });
+
+  it('replaces existing keys in place without duplicating', () => {
+    const base = 'FOO=old\nBAZ=keep\n';
+    const out = mergeEnvContent(base, new Map([['FOO', 'new']]));
+    expect(out).toBe('FOO=new\nBAZ=keep\n');
+    expect(out.match(/^FOO=/gm)).toHaveLength(1);
+  });
+
+  it('handles base without trailing newline', () => {
+    const out = mergeEnvContent('FOO=one', new Map([['BAR', 'two']]));
+    expect(out).toBe('FOO=one\nBAR=two\n');
+  });
+
+  it('escapes regex metacharacters in keys', () => {
+    // Not a realistic env key but proves we don't explode.
+    const out = mergeEnvContent('K.E=orig\n', new Map([['K.E', 'new']]));
+    expect(out).toBe('K.E=new\n');
+  });
+});
+
+describe('createEnvStaging — atomicity', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('stage() does not touch disk', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('FOO', 'bar');
+    expect(existsSync(join(dir, '.env'))).toBe(false);
+    expect(staging.pendingCount()).toBe(1);
+  });
+
+  it('commit() writes atomically and clears staging', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('FOO', 'bar');
+    staging.commit();
+    expect(readFileSync(join(dir, '.env'), 'utf-8')).toBe('FOO=bar\n');
+    expect(staging.pendingCount()).toBe(0);
+    expect(existsSync(join(dir, '.env.tmp'))).toBe(false);
+  });
+
+  it('commit() writes a .env.bak backup when an existing .env is present', () => {
+    const envPath = join(dir, '.env');
+    writeFileSync(envPath, 'EXISTING=1\n', 'utf-8');
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('NEW', 'v');
+    staging.commit();
+    expect(existsSync(join(dir, '.env.bak'))).toBe(true);
+    expect(readFileSync(join(dir, '.env.bak'), 'utf-8')).toBe('EXISTING=1\n');
+    expect(readFileSync(envPath, 'utf-8')).toBe('EXISTING=1\nNEW=v\n');
+  });
+
+  it('rollback() leaves pre-init .env bytewise unchanged (the #34 acceptance test)', () => {
+    const envPath = join(dir, '.env');
+    const original = 'KEYOKU_EXTRACTION_PROVIDER=ollama\nOLLAMA_BASE_URL=http://localhost:11434\n';
+    writeFileSync(envPath, original, 'utf-8');
+
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('KEYOKU_EXTRACTION_PROVIDER', 'gemini');
+    staging.stage('KEYOKU_EMBEDDING_PROVIDER', 'gemini');
+    // User aborts before entering GEMINI_API_KEY.
+    staging.rollback();
+
+    expect(readFileSync(envPath, 'utf-8')).toBe(original);
+    expect(staging.pendingCount()).toBe(0);
+  });
+
+  it('rollback() restores .env from .env.bak when a partial commit already landed', () => {
+    const envPath = join(dir, '.env');
+    const original = 'FOO=pristine\n';
+    writeFileSync(envPath, original, 'utf-8');
+
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('FOO', 'dirty');
+    staging.commit();
+    expect(readFileSync(envPath, 'utf-8')).toBe('FOO=dirty\n');
+
+    // Something downstream errored; the init flow invokes rollback.
+    staging.rollback();
+    expect(readFileSync(envPath, 'utf-8')).toBe(original);
+  });
+
+  it('rollback() removes a stray .env.tmp from a crashed write', () => {
+    writeFileSync(join(dir, '.env.tmp'), 'GARBAGE=1\n', 'utf-8');
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.rollback();
+    expect(existsSync(join(dir, '.env.tmp'))).toBe(false);
+  });
+
+  it('effective() returns staged value before commit, process.env after clear', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('STAGED_ONLY', 'x');
+    expect(staging.effective('STAGED_ONLY')).toBe('x');
+    expect(staging.effective('NEVER_SET')).toBeUndefined();
+  });
+
+  it('commit() is idempotent / a no-op when nothing is staged', () => {
+    writeFileSync(join(dir, '.env'), 'FOO=keep\n', 'utf-8');
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.commit();
+    // Should not have created a backup since we never staged anything.
+    expect(existsSync(join(dir, '.env.bak'))).toBe(false);
+    expect(readFileSync(join(dir, '.env'), 'utf-8')).toBe('FOO=keep\n');
+  });
+});
+
+describe('assertProviderCredentials', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    for (const k of Object.values(PROVIDER_REQUIRED_KEYS)) delete process.env[k];
+  });
+
+  it('throws when a provider switch lacks its credential', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    expect(() => assertProviderCredentials(staging, 'gemini')).toThrow(/GEMINI_API_KEY/);
+  });
+
+  it('passes when the credential is staged in the same transaction', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    staging.stage('GEMINI_API_KEY', 'fake-key');
+    expect(() => assertProviderCredentials(staging, 'gemini')).not.toThrow();
+  });
+
+  it('passes when the credential is inherited from process.env', () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    expect(() => assertProviderCredentials(staging, 'openai')).not.toThrow();
+  });
+
+  it('reports all missing providers at once (so users fix all at once)', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    try {
+      assertProviderCredentials(staging, 'gemini', 'anthropic');
+      throw new Error('expected throw');
+    } catch (e) {
+      expect((e as Error).message).toMatch(/gemini/);
+      expect((e as Error).message).toMatch(/anthropic/);
+    }
+  });
+
+  it('ignores unknown providers gracefully (no false-positive rejection)', () => {
+    const staging = createEnvStaging({ dir, mirrorProcessEnv: false });
+    expect(() => assertProviderCredentials(staging, 'pigeon-llm')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #34.

Makes all `~/.keyoku/.env` writes in `keyoku-init` transactional, so an interrupted or errored init can never leave the engine pointing at a provider whose credential was never entered.

- New `src/env-atomic.ts`: `createEnvStaging()` with stage → validate → atomic `rename(.env.tmp, .env)` and `.env.bak` backup on every replace. `rollback()` restores from backup or clears a stray tmp.
- `src/init.ts`: `appendToEnvFile()` now stages into the module; no disk write until `commitEnvStaging()`. SIGINT/SIGTERM rollback handler installed at `init()` entry. `setupLlmProvider()` gates commit on `assertProviderCredentialsStaged()` so a Gemini/OpenAI/Anthropic switch is refused unless its key is in the staged set or `process.env`. Commit happens at end of the LLM provider phase so downstream steps still see a complete `.env`. `init()` wraps `runInit()` in try/catch → `rollbackEnvStaging()` for any thrown error after commit.

## Why
moltar-bot's repro (issue #34): user selected Gemini, `.env` was rewritten mid-run to `KEYOKU_EXTRACTION_PROVIDER=gemini` / `KEYOKU_EMBEDDING_PROVIDER=gemini`, `GEMINI_API_KEY` never entered, and keyoku-engine refused to boot (`failed to initialize keyoku: failed to create LLM provider: API key is required for provider gemini`). That cascaded into OpenClaw memory `fetch failed`. The harness previously had no contract for `.env` atomicity — that's been added as [harness/20-contracts/config.md §Atomicity](https://github.com/Keyoku-ai/keyoku-harness/blob/main/20-contracts/config.md) in the companion spec PR.

## Harness changes (companion)
Atomicity contract added to `20-contracts/config.md` with the five required rules: stage-then-commit / atomic replace / backup on replace / signal safe / credential gate.

## Validation
- `test/env-atomic.test.ts` — 17 unit tests covering merge semantics, staging no-disk-touch, atomic commit, backup creation, rollback preserves bytewise identity (the #34 acceptance test), rollback restores from a partial commit, stray `.env.tmp` cleanup, credential gate rejection / acceptance, multi-provider error message.
- `npx vitest run` — full openclaw suite: **207/207 passing**.
- `npx tsc --noEmit` — clean.

## Test plan
- [x] Unit: all 17 env-atomic tests
- [x] Unit: full openclaw suite stays green
- [ ] Manual: `keyoku-init` → choose Gemini → ^C at API-key prompt → start keyoku-engine → should boot with original Ollama config unchanged (pre-fix: fails with `API key is required for provider gemini`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)