### PR TITLE
feat: activity-backfill for build-then-verify workflows + config knobs (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## 2.2.0 — 2026-06-18
+
+- **Muscle memory fills itself — activity-backfilled workflows.** Builds on 2.1.0:
+  a goal that converges build-then-verify with **nothing recorded** no longer learns
+  nothing. When the action trace is empty, the engine now infers the workflow steps
+  from the **activity log** within the goal's lifetime (`createdAt → now`), keeping
+  only real *action* events — mutating Bash / Edit / Write / connector calls, never
+  inspection (`ls`, `cat`, Reads…) or the harness's own `mcp__keyoku__*` bookkeeping
+  — collapsed and capped. Inferred steps are labeled `source: "activity"` so the
+  trace stays honest about provenance; an explicit `goal_record` always wins over
+  inference. This closes the real-world gap the audit found: every one of a heavy
+  user's converged goals had `steps: 0` because `goal_record` wasn't called mid-run.
+  Fully back-compat (no activity ⇒ no workflow, exactly as before). Deterministic and
+  synchronous — the convergence core is untouched; the SLM-backed `workflow_suggest`
+  / `harness_learn` passes can still refine the draft. (engine; regression test in
+  `tests/engine.test.ts`.)
+- **Configurable workflow-suggestion relevance.** The Jaccard similarity floor and
+  result count for surfacing a learned workflow on a new goal are now knobs, not
+  magic numbers: `KEYOKU_WF_MIN_SIMILARITY` (default `0.2`) and
+  `KEYOKU_WF_SUGGEST_LIMIT` (default `2`). Recall is a tunable decision; the
+  pass/fail convergence check remains purely deterministic.
+- **Docs**: `docs/REPO-MAP.md` names the one canonical, published package and what
+  every neighbouring repo is; `docs/PUBLISHING.md` documents the one-time Trusted
+  Publishing toggle the release workflow expects.
+
 ## 2.1.0 — 2026-06-18
 
 - **Muscle memory for build-then-verify runs** (closes a gap vs. the "converged

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The division of labor: **heuristics** generate candidates for free, the **small 
 | `KEYOKU_SLM_PROVIDER` | auto | `gemini`, `anthropic`, `openai-compat`, or `none` |
 | `KEYOKU_SLM_BASE_URL` / `KEYOKU_SLM_MODEL` | — | Any OpenAI-compatible endpoint (Ollama, LM Studio, LiteLLM, Groq, …) |
 | `KEYOKU_ENGINE_URL` | — | Connect a running [keyoku-engine](https://github.com/Keyoku-ai/keyoku-engine): knowledge mirrors into it and queries upgrade to semantic search |
+| `KEYOKU_WF_MIN_SIMILARITY` | `0.2` | Jaccard floor for suggesting a learned workflow on a new goal |
+| `KEYOKU_WF_SUGGEST_LIMIT` | `2` | Max learned workflows surfaced per assessment |
 | `KEYOKU_DEBUG` | — | Full error stacks |
 
 ## Security

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,51 @@
+# Publishing
+
+Releases are tag-driven. Pushing a `v*` tag runs `.github/workflows/release.yml`,
+which typechecks, tests, runs the muscle-memory eval (a hard quality gate), and
+then publishes to npm. The workflow is **idempotent** — it skips a version that is
+already on npm — and it **never reports a false success**: if no publish auth is
+configured it emits a loud warning and exits 0 rather than pretending it shipped.
+
+## Cut a release
+
+1. Bump `version` in `package.json` and add a `CHANGELOG.md` entry.
+2. Commit, then tag and push:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+3. Watch the **Release** workflow. Green + "Published keyoku@X.Y.Z with provenance"
+   means done.
+
+## One-time auth setup (the only manual gap)
+
+The workflow code is complete; npm just needs to trust it. Pick **one**:
+
+### Option A — Trusted Publishing (recommended: tokenless + provenance)
+
+No secret to manage. On npmjs.com:
+
+> package **`keyoku`** → **Settings** → **Trusted Publishing** → add publisher:
+> repository **`Keyoku-ai/keyoku`**, workflow **`release.yml`**.
+
+The workflow already requests the OIDC token (`permissions: id-token: write`) and
+upgrades npm to a version that supports OIDC, so once this is added the next tag
+publishes automatically with provenance.
+
+### Option B — `NPM_TOKEN` secret (fallback)
+
+Create an **Automation** access token on npmjs.com and add it as the repo secret
+`NPM_TOKEN` (Settings → Secrets and variables → Actions). The workflow already
+wires `NODE_AUTH_TOKEN` from it.
+
+## Manual fallback
+
+Until A or B is configured, publish from an authenticated maintainer machine:
+
+```bash
+npm run build
+npm publish --access public
+```
+
+This is safe to run anytime — npm rejects a re-publish of an existing version,
+matching the workflow's idempotency.

--- a/docs/REPO-MAP.md
+++ b/docs/REPO-MAP.md
@@ -1,0 +1,49 @@
+# Repo map — what's canonical, and what everything else is
+
+There are several directories named `keyoku*` across the workspace, and **two
+different packages literally named `keyoku`**. This note removes the ambiguity.
+
+## The one canonical, published package
+
+**This repo (`keyoku-harness/`) is `keyoku` on npm** — the convergence + muscle-memory
+harness, MCP-native, with the `keyoku` CLI.
+
+| | |
+|---|---|
+| npm | [`keyoku`](https://www.npmjs.com/package/keyoku) (the `latest` dist-tag) |
+| package name | `keyoku` (see `package.json`) |
+| bin | `keyoku` → `dist/index.js` |
+| install | `npm install -g keyoku && keyoku init` |
+| repo | `github.com/Keyoku-ai/keyoku` |
+| site | `keyoku.ai` |
+
+If you are installing, depending on, or contributing to "Keyoku" — this is it.
+Everything below is supporting or historical and is **not** what `npm i keyoku`
+gives you.
+
+## Supporting components (not this npm package)
+
+- **`keyoku-engine/`** — the optional Go backend for teams: knowledge graph,
+  semantic search, memory decay, cross-device sync. The harness runs fully
+  standalone without it; set `KEYOKU_ENGINE_URL` to connect one.
+  Repo: `github.com/Keyoku-ai/keyoku-engine`.
+- **`keyoku-site/`** — the marketing site for `keyoku.ai` (deployed separately).
+
+## Historical / sibling (do not confuse with the published package)
+
+- **`../Keyoku Harness/keyoku/`** — an **earlier, private** package *also* named
+  `keyoku` (v1.x), the original **AI-memory SDK** (auto-recall / auto-capture /
+  heartbeat) from before the harness became the product. It is **not** published as
+  the current `keyoku` and is not what this repo builds. Treat it as legacy unless
+  you are specifically working on the memory SDK lineage.
+- **`keyoku-node/` (`@keyoku/sdk`), `keyoku-python/`, `keyoku-embedded/`,
+  `keyoku-bot/`, `keyoku-dashboard/`, `keyoku-git*`, `keyoku-infra/`,
+  `keyoku-demo/`** — experiments, SDKs, deploy infra, and demos in the broader
+  Keyoku family. None of them is the published `keyoku` CLI.
+
+## Rule of thumb
+
+> When someone says "Keyoku," they mean **this package** (`keyoku-harness` →
+> npm `keyoku`). The convergence loop and muscle memory live here. Anything else
+> is a satellite — name it explicitly (`keyoku-engine`, the memory SDK, the site)
+> to avoid the collision.

--- a/evals/behavioral/README.md
+++ b/evals/behavioral/README.md
@@ -1,0 +1,43 @@
+# evals/behavioral/ — does muscle memory change behavior?
+
+The deterministic eval (`../muscle-memory.eval.ts`) proves muscle memory is **captured and
+retrieved**. This one proves it is **useful** — that an agent *given* a learned workflow +
+pitfall plans/acts better than one without. That is the actual product claim, so it gets its
+own validation.
+
+This eval is **model-driven** (an agent is the subject), so it is **not** in the CI gate —
+run it on demand and record directional results, the way the deterministic eval records exact
+ones.
+
+## Run
+
+Each cell is one (scenario × condition). Generate the prompt and hand it to a fresh agent
+(subagent / `claude -p` / any harness):
+
+```bash
+tsx evals/behavioral/build-prompt.ts S-DEPLOY naive
+tsx evals/behavioral/build-prompt.ts S-DEPLOY equipped
+# … for each scenario in scenarios.json × {naive, equipped}
+```
+
+`naive` and `equipped` differ only by the injected block — exactly what keyoku's `goal_assess`
+guidance surfaces for a similar converged goal (the learned step + `avoid (failed before): …`).
+Collect each plan, grade per [`RUBRIC.md`](./RUBRIC.md), and write a dated file under
+`results/`.
+
+## Metrics
+
+- **Good-step adoption lift** = adoption(equipped) − adoption(naive)
+- **Pitfall-guard lift** = guards(equipped) − guards(naive)
+
+Latest run: [`results/2026-06-18-planning-lift.md`](./results/2026-06-18-planning-lift.md) —
+adoption 1/3 → 3/3, pitfall-guard 0/3 → 3/3 (Opus-class, n=1).
+
+## Roadmap (stronger evidence)
+
+- **Execution eval:** drive a real agent loop to convergence; count iterations and whether it
+  hit the dead end, naive vs equipped. Planning probes show intent; execution shows outcome.
+- **Weaker-model row:** the lift grows as the base agent knows less — run a cheap model to
+  show the realistic at-scale gap.
+- **Auto-recorded workflows:** once auto-record lands (`feat/auto-record`), seed this eval from
+  *real* captured workflows instead of hand-authored memory, closing the loop end to end.

--- a/evals/behavioral/RUBRIC.md
+++ b/evals/behavioral/RUBRIC.md
@@ -1,0 +1,37 @@
+# Behavioral-lift rubric
+
+Each cell is one (scenario × condition) single-shot planning probe. Grade from the returned
+JSON `first_steps` + `reasoning` only — never from a self-report about what the agent "would"
+do differently.
+
+For each scenario the muscle memory is **project-specific** (a naive agent cannot guess it),
+so adoption by the equipped agent that is absent in naive is attributable to the injected
+workflow.
+
+Per cell, mark two booleans (case-insensitive substring match over `first_steps` + `reasoning`):
+
+- **adopted** — the plan includes the learned good step (`good_signal` tokens present).
+- **guards** — the plan explicitly addresses the known pitfall the right way (`pitfall_signal`
+  present AND the plan does not propose the dead-end itself).
+
+## Metrics (the headline)
+
+- **Good-step adoption lift** = adoption(equipped) − adoption(naive).
+- **Pitfall-guard lift** = guards(equipped) − guards(naive).
+
+A positive lift across scenarios is direct evidence that muscle memory changes agent behavior
+for the better — i.e. the value prop fires, not just the capture.
+
+## Verdicts
+
+- **Lift confirmed** — equipped adopts/guards where naive does not (lift > 0 on both).
+- **No lift** — naive already does it (memory is redundant for this scenario) OR equipped
+  ignores the injected guidance (a wording/surfacing problem — fix guidance, re-run).
+
+## Caveats
+
+- Single-shot **planning** probes — intentions, not executed artifacts. Directional. The
+  stronger follow-up is an execution eval (drive a real agent loop, count iterations to
+  converge and whether it actually hit the dead end).
+- Report n per cell and the model used. Small models are fine for direction; reproduce on a
+  stronger model before treating a number as publication-grade.

--- a/evals/behavioral/build-prompt.ts
+++ b/evals/behavioral/build-prompt.ts
@@ -1,0 +1,45 @@
+/**
+ * Deterministic prompt composer for the behavioral-lift eval.
+ *
+ *   tsx evals/behavioral/build-prompt.ts <SCENARIO_ID> <naive|equipped>
+ *
+ * naive    — just the goal.
+ * equipped — the goal PLUS exactly what keyoku's assess guidance injects for a similar
+ *            converged goal (the learned workflow step + the "avoid (failed before)" pitfall).
+ *
+ * The two prompts are identical except for that injected block, so any behavior delta is
+ * attributable to the muscle memory — no demand characteristics (we never label the "right"
+ * answer, and the response schema is the same for both).
+ */
+import { readFileSync } from "node:fs";
+
+const scenarios = JSON.parse(
+  readFileSync(new URL("./scenarios.json", import.meta.url), "utf8"),
+) as Record<string, any>;
+
+const [id, condition] = process.argv.slice(2);
+if (!scenarios[id] || id === "_doc" || !["naive", "equipped"].includes(condition)) {
+  const ids = Object.keys(scenarios).filter((k) => k !== "_doc").join("|");
+  console.error(`usage: tsx evals/behavioral/build-prompt.ts <${ids}> <naive|equipped>`);
+  process.exit(1);
+}
+
+const s = scenarios[id];
+const RESPONSE = `Reply with ONLY a JSON object, no other text:
+{"first_steps": ["..."], "reasoning": "<= 50 words"}
+where first_steps is an ordered list of 3-5 concrete actions you would take FIRST (be specific about commands/files), and reasoning is your rationale in 50 words or fewer.`;
+
+const parts: string[] = [
+  `You are a coding agent picking up a task in an existing repository.`,
+  `Goal: ${s.goal}.`,
+];
+if (condition === "equipped") {
+  // Mirrors keyoku's buildGuidance output verbatim in shape.
+  parts.push(
+    `Learned workflows from similar converged goals:\n` +
+      `  • '${s.memory.slug}' (converged ${s.memory.convergences}x, similarity ${s.memory.similarity}): ${s.memory.step}\n` +
+      `    avoid (failed before): ${s.memory.pitfall}`,
+  );
+}
+parts.push(RESPONSE);
+process.stdout.write(parts.join("\n\n") + "\n");

--- a/evals/behavioral/results/2026-06-18-planning-lift.md
+++ b/evals/behavioral/results/2026-06-18-planning-lift.md
@@ -1,0 +1,43 @@
+# Behavioral-lift eval — 2026-06-18 (planning probes)
+
+**Question:** does muscle memory actually change an agent's behavior, or do we only know it's
+captured/retrieved? This is the value-side validation the deterministic eval can't give.
+
+**Method:** 3 scenarios × {naive, equipped}, single-shot planning probes from
+`build-prompt.ts`, each given to a fresh agent (Opus-class, the session default), graded per
+`RUBRIC.md`. n=1 per cell. Each scenario's good step + pitfall is **project-specific** (a
+naive agent can't guess it), so adoption present in equipped but absent in naive is
+attributable to the injected workflow.
+
+## Results
+
+| scenario | learned step | naive adopts | equipped adopts | naive guards pitfall | equipped guards |
+|---|---|---|---|---|---|
+| S-DEPLOY | `make preflight` gate | ✗ | ✓ | ✗ | ✓ |
+| S-DB | snapshot → `migrations-backup` first | ✗ (no backup proposed) | ✓ | ✗ | ✓ |
+| S-FLAKY | pin clock via FakeClock helper | ~ (generic "deterministic clock") | ✓ (names the helper) | ✗ | ✓ (cites "only masks it") |
+
+## Metrics
+
+- **Good-step adoption:** naive **1/3** (33%, and the one hit was generic, not the project
+  helper) → equipped **3/3** (100%). **Lift +2/3 clear, +1/3 specificity.**
+- **Pitfall guard:** naive **0/3** → equipped **3/3**. **Lift +3/3.**
+
+## Verdict
+
+**Lift confirmed.** Muscle memory measurably improves the plan — most on **non-obvious,
+project-specific** procedures (preflight gate, the backup bucket) and on **avoiding known
+dead ends** everywhere. Notably the strong naive agent did **not** propose a backup before a
+destructive migration; the equipped one did, because the pitfall was in its memory.
+
+## Caveats (honest)
+
+- **n=1, planning probes, strong model.** Intentions, not executed artifacts. A strong naive
+  baseline *understates* the lift — with a weaker/cheaper agent (the realistic at-scale case)
+  the gap widens, because more of the good step is non-obvious to it.
+- The value is **largest for project-specific / hard-won knowledge** and **smallest where the
+  good practice is already common knowledge** (S-FLAKY adoption tied; the win there was
+  specificity + pitfall-avoidance). This is the honest shape of the value prop: keyoku pays
+  off most on what a base model *doesn't already know*.
+- Stronger follow-up (next): an **execution** eval — drive a real agent loop and count
+  iterations-to-converge and whether it actually hit the dead end, naive vs equipped.

--- a/evals/behavioral/scenarios.json
+++ b/evals/behavioral/scenarios.json
@@ -1,0 +1,39 @@
+{
+  "_doc": "Behavioral-lift scenarios. Each goal has PROJECT-SPECIFIC muscle memory (a non-obvious good step + a real dead-end pitfall) that a naive agent cannot guess. The equipped condition receives exactly what keyoku's assess guidance injects. We measure whether the equipped plan adopts the good step and guards the pitfall, vs naive.",
+  "S-DEPLOY": {
+    "goal": "deploy the production service to kubernetes",
+    "memory": {
+      "slug": "deploy-staging-k8s",
+      "convergences": 3,
+      "similarity": 0.61,
+      "step": "run `make preflight` first (the repo's required pre-deploy gate), then apply the chart",
+      "pitfall": "deployed without running make preflight — shipped a broken config"
+    },
+    "good_signal": ["preflight"],
+    "pitfall_signal": ["preflight"]
+  },
+  "S-DB": {
+    "goal": "migrate the orders table to the new schema",
+    "memory": {
+      "slug": "migrate-postgres-schema",
+      "convergences": 2,
+      "similarity": 0.55,
+      "step": "snapshot to the `migrations-backup` bucket first, then run the migration",
+      "pitfall": "ran the migration with no snapshot — irrecoverable data loss"
+    },
+    "good_signal": ["snapshot", "backup", "migrations-backup"],
+    "pitfall_signal": ["snapshot", "backup"]
+  },
+  "S-FLAKY": {
+    "goal": "fix the flaky auth test",
+    "memory": {
+      "slug": "fix-flaky-tests",
+      "convergences": 4,
+      "similarity": 0.7,
+      "step": "pin the system clock via the FakeClock test helper",
+      "pitfall": "bumped the test timeout — only masks the flake, it comes back"
+    },
+    "good_signal": ["fakeclock", "clock"],
+    "pitfall_signal": ["timeout"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyoku",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The harness with muscle memory — watches what you do in Claude Code, Cursor, or Codex, learns your patterns, and turns them into reusable MCP-native workflows.",
   "type": "module",
   "bin": {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -200,7 +200,7 @@ const INSPECTION_RE =
   /^(ls|cat|grep|rg|find|head|tail|pwd|which|wc|tree|echo|man|type|stat|du|df|env|printenv|git (status|diff|log|show|branch|blame|remote)|npm (ls|view|outdated|info)|docker (ps|images)|kubectl (get|describe))\b/;
 
 /** Does this event change anything, or is it just looking around? */
-function isActionEvent(ev: ActivityEvent): boolean {
+export function isActionEvent(ev: ActivityEvent): boolean {
   if (ev.type === "file_change") return true;
   if (ev.tool === "connector_call") return true;
   if (ev.tool === "Bash" || ev.type === "shell" || ev.type === "git") {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,3 +1,4 @@
+import { isActionEvent } from "./activity.js";
 import { evaluateAssertion } from "./assert.js";
 import type { ConnectorManager } from "./connectors.js";
 import { buildGuidance } from "./guidance.js";
@@ -16,6 +17,7 @@ import type {
   CriterionInput,
   Goal,
   WorkflowArtifact,
+  WorkflowStep,
   WorkflowSuggestion,
 } from "./types.js";
 
@@ -39,6 +41,28 @@ function jaccard(a: Set<string>, b: Set<string>): number {
   for (const t of a) if (b.has(t)) intersection++;
   return intersection / (a.size + b.size - intersection);
 }
+
+// Workflow-suggestion tuning. Surfacing a learned workflow on a new goal is a
+// recall decision, not a correctness one — so the relevance bar is a knob, not
+// a magic number baked into the loop. Lower it to cast a wider net, raise it to
+// suppress weak matches. The convergence core stays purely deterministic.
+function envFloat(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+function envInt(name: string, fallback: number): number {
+  const n = envFloat(name, fallback);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+const WORKFLOW_SUGGESTION_MIN_SIMILARITY = envFloat("KEYOKU_WF_MIN_SIMILARITY", 0.2);
+const WORKFLOW_SUGGESTION_LIMIT = envInt("KEYOKU_WF_SUGGEST_LIMIT", 2);
+
+// Activity-backfill cap: when a goal converges with nothing recorded, at most
+// this many inferred steps are lifted from the activity log so the workflow
+// isn't a hollow shell. A bound, not a retention contract.
+const MAX_BACKFILL_STEPS = 30;
 
 const MAX_ACTUAL_CHARS = 2_000;
 
@@ -378,11 +402,18 @@ export class Harness {
     const failures = trace.filter((r) => r.result === "failure").map((r) => r.summary);
 
     const existing = this.store.getWorkflow(goal.slug);
-    // Promote only when there is something to learn — steps, pitfalls, or an
-    // existing workflow to preserve. A truly empty convergence (nothing recorded)
-    // learns nothing and must not become a hollow artifact; a retroactive
-    // goal_record then promotes it.
-    if (steps.length === 0 && failures.length === 0 && !existing) return null;
+    // Build-then-verify: the goal converged but the agent recorded nothing
+    // through goal_record. The real work still happened — it's sitting in the
+    // activity log — so infer the steps from there rather than learn a hollow
+    // workflow. Inferred steps are labeled source:"activity" to stay honest
+    // about provenance, and an explicit goal_record always wins over inference.
+    const effectiveSteps: WorkflowStep[] =
+      steps.length > 0 ? steps : this.backfillStepsFromActivity(goal);
+    // Promote only when there is something to learn — steps (recorded OR
+    // inferred), pitfalls, or an existing workflow to preserve. A convergence
+    // with no records AND no relevant activity learns nothing and must not
+    // become a hollow artifact; a retroactive goal_record then promotes it.
+    if (effectiveSteps.length === 0 && failures.length === 0 && !existing) return null;
     // Deduped, newest-last, capped — pitfalls accumulate across re-convergences.
     const pitfalls = [...new Set([...(existing?.pitfalls ?? []), ...failures])].slice(-20);
     const now = new Date().toISOString();
@@ -392,7 +423,7 @@ export class Harness {
           objective: goal.objective,
           // Keep the richer trace: a re-convergence with no new actions
           // (steady-state check) shouldn't erase the learned steps.
-          steps: steps.length > 0 ? steps : existing.steps,
+          steps: effectiveSteps.length > 0 ? effectiveSteps : existing.steps,
           criteria: goal.criteria.map((c) => c.description),
           ...(pitfalls.length > 0 ? { pitfalls } : {}),
           stats: {
@@ -407,7 +438,7 @@ export class Harness {
           id: newId("wf"),
           slug: goal.slug,
           objective: goal.objective,
-          steps,
+          steps: effectiveSteps,
           criteria: goal.criteria.map((c) => c.description),
           ...(pitfalls.length > 0 ? { pitfalls } : {}),
           stats: { convergences: 1, totalActions: trace.length },
@@ -416,6 +447,49 @@ export class Harness {
         };
     this.store.saveWorkflow(workflow);
     return workflow;
+  }
+
+  /**
+   * Infer workflow steps for a goal that converged with nothing recorded
+   * (build-then-verify). Scope = action events — mutating Bash / Edit / Write /
+   * connector calls, never inspection or the harness's own bookkeeping —
+   * observed since the goal was created. Deterministic and synchronous: it lifts
+   * what actually happened from the activity log, it does not decide anything.
+   * The log interleaves concurrent sessions, so this is a best-effort draft
+   * (labeled source:"activity"), not a verified trace; the SLM-backed
+   * workflow_suggest / harness_learn passes can refine it. The point is to stop
+   * the product's headline feature — muscle memory — from silently producing
+   * empty workflows just because the agent didn't call goal_record mid-run.
+   */
+  private backfillStepsFromActivity(goal: Goal): WorkflowStep[] {
+    const since = Date.parse(goal.createdAt);
+    if (Number.isNaN(since)) return [];
+    const events = this.store.listActivity().filter((e) => {
+      const t = Date.parse(e.at);
+      if (Number.isNaN(t) || t < since) return false;
+      const tool = e.tool ?? "";
+      // The harness's own MCP calls (goal_*, workflow_*, …) are bookkeeping, not
+      // the work being learned.
+      if (tool.startsWith("mcp__keyoku__") || tool.startsWith("keyoku")) return false;
+      return isActionEvent(e);
+    });
+    // Collapse consecutive identical actions (a formatter rewriting one file ten
+    // times is one step, not ten), then cap to the most recent steps.
+    const steps: WorkflowStep[] = [];
+    let lastKey = "";
+    for (const e of events) {
+      const summary = e.summary.slice(0, 200);
+      const key = `${e.tool ?? e.type}:${summary}`;
+      if (key === lastKey) continue;
+      lastKey = key;
+      steps.push({
+        summary,
+        ...(e.tool ? { tool: e.tool } : {}),
+        result: "success" as const,
+        source: "activity" as const,
+      });
+    }
+    return steps.slice(-MAX_BACKFILL_STEPS);
   }
 
   suggestWorkflows(goal: Goal): WorkflowSuggestion[] {
@@ -431,8 +505,8 @@ export class Harness {
         steps: w.steps,
         ...(w.pitfalls && w.pitfalls.length > 0 ? { pitfalls: w.pitfalls } : {}),
       }))
-      .filter((s) => s.similarity >= 0.2)
+      .filter((s) => s.similarity >= WORKFLOW_SUGGESTION_MIN_SIMILARITY)
       .sort((a, b) => b.similarity - a.similarity)
-      .slice(0, 2);
+      .slice(0, WORKFLOW_SUGGESTION_LIMIT);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,11 @@ export interface WorkflowStep {
   summary: string;
   tool?: string;
   result: ActionResult;
+  /** Provenance: "recorded" = an explicit goal_record corrective action;
+   *  "activity" = inferred from the activity log because the goal converged
+   *  build-then-verify with nothing recorded. Absent means recorded
+   *  (back-compat with workflows persisted before this field existed). */
+  source?: "recorded" | "activity";
 }
 
 export interface WorkflowArtifact {

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ConnectorManager } from "../src/connectors.js";
 import { Harness, type CreateGoalInput } from "../src/engine.js";
 import { Store } from "../src/store.js";
+import type { ActivityEvent } from "../src/types.js";
 
 let dir: string;
 let harness: Harness;
@@ -253,6 +254,43 @@ describe("the convergence loop", () => {
     const workflows = harness.store.listWorkflows();
     expect(workflows).toHaveLength(1);
     expect(workflows[0].steps.map((s) => s.summary)).toEqual(["Did the real work"]);
+  });
+
+  it("build-then-verify with activity: an empty trace backfills steps from the activity log", async () => {
+    const goal = harness.createGoal({
+      objective: "activity backfill works",
+      criteria: [
+        {
+          description: "echo ok",
+          probe: { kind: "command", run: "echo ok", parse: "text" },
+          assert: { op: "eq", value: "ok" },
+        },
+      ],
+    });
+    let seq = 0;
+    const ev = (over: Partial<ActivityEvent>): ActivityEvent => ({
+      id: `e${seq++}`,
+      type: "tool_use",
+      summary: "x",
+      at: new Date().toISOString(),
+      ...over,
+    });
+    // Real work — must be captured, in order:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: src/server.ts" }));
+    harness.store.appendActivity(ev({ type: "shell", tool: "Bash", summary: "Bash: npm run build", detail: "npm run build" }));
+    // Noise — must be excluded:
+    harness.store.appendActivity(ev({ tool: "Read", summary: "Read: src/server.ts" })); // inspection
+    harness.store.appendActivity(ev({ type: "shell", tool: "Bash", summary: "Bash: ls -la", detail: "ls -la" })); // inspection cmd
+    harness.store.appendActivity(ev({ tool: "mcp__keyoku__goal_assess", summary: "assessed" })); // harness bookkeeping
+    // Out of the goal's lifetime — must be excluded by the time window:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: old.ts", at: "2000-01-01T00:00:00.000Z" }));
+
+    const conv = await harness.assess(goal.slug);
+    expect(conv.converged).toBe(true);
+    const wf = harness.store.getWorkflow(goal.slug);
+    expect(wf).toBeTruthy();
+    expect(wf?.steps.map((s) => s.summary)).toEqual(["Edit: src/server.ts", "Bash: npm run build"]);
+    expect(wf?.steps.every((s) => s.source === "activity")).toBe(true);
   });
 
   it("muscle memory is REUSED — a similar goal gets the converged workflow suggested", async () => {


### PR DESCRIPTION
## Summary

Audit-driven fixes so **muscle memory stops producing hollow workflows**. The audit found that every converged goal in real usage had `steps: 0` — goals converge build-then-verify (do the work, assess once) without calling `goal_record`, so the promoted workflows were empty shells.

## Changes

- **Activity-backfill for build-then-verify workflows** — when a goal converges with no recorded actions, the engine infers workflow steps from the activity log within the goal's lifetime (`createdAt → now`). Keeps only real action events (mutating Bash/Edit/Write/connector), excludes inspection (`ls`/`cat`/Reads), the harness's own `mcp__keyoku__*` bookkeeping, and out-of-window events; collapses consecutive dups; caps at 30. Inferred steps are labeled `source: "activity"` for honest provenance. Deterministic + synchronous — **the convergence core is untouched**. An explicit `goal_record` always wins over inference. Fully back-compat: no activity ⇒ no workflow (existing "no hollow workflow" test stays green).
- **Configurable workflow-suggestion relevance** — `KEYOKU_WF_MIN_SIMILARITY` (default `0.2`) and `KEYOKU_WF_SUGGEST_LIMIT` (default `2`) replace hardcoded constants. Recall is tunable; the pass/fail convergence check stays deterministic.
- **Docs** — `docs/REPO-MAP.md` (which package is canonical) and `docs/PUBLISHING.md` (one-time Trusted Publishing setup).
- Version bump `2.1.0 → 2.2.0`, CHANGELOG + README updated.

## Verification

- `npm run typecheck` clean
- **244/244 tests** pass (+1 new regression test in `tests/engine.test.ts`)
- `npm run eval` (muscle-memory retrieval) **PASS** — 100% precision@1, 0% false positives
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
