### PR TITLE
feat: backfill lookback + dominant-session scoping (proof-driven follow-up to #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@
 - **Muscle memory fills itself — activity-backfilled workflows.** Builds on 2.1.0:
   a goal that converges build-then-verify with **nothing recorded** no longer learns
   nothing. When the action trace is empty, the engine now infers the workflow steps
-  from the **activity log** within the goal's lifetime (`createdAt → now`), keeping
-  only real *action* events — mutating Bash / Edit / Write / connector calls, never
-  inspection (`ls`, `cat`, Reads…) or the harness's own `mcp__keyoku__*` bookkeeping
-  — collapsed and capped. Inferred steps are labeled `source: "activity"` so the
+  from the **activity log** over the window `[createdAt − lookback, convergedAt]`,
+  keeping only real *action* events — mutating Bash / Edit / Write / connector calls,
+  never inspection (`ls`, `cat`, Reads…) or the harness's own `mcp__keyoku__*`
+  bookkeeping — collapsed and capped. Two refinements proven against real data:
+  a **lookback** (default 45 min, `KEYOKU_BACKFILL_LOOKBACK_MIN`) catches work done
+  *just before* the goal was declared (build-then-verify goals can have 2–4 s
+  lifetimes — all the work precedes `goal_create`); and **dominant-session scoping**
+  keeps a goal from inheriting a concurrent project's edits (the global log
+  interleaves sessions). Inferred steps are labeled `source: "activity"` so the
   trace stays honest about provenance; an explicit `goal_record` always wins over
   inference. This closes the real-world gap the audit found: every one of a heavy
   user's converged goals had `steps: 0` because `goal_record` wasn't called mid-run.
   Fully back-compat (no activity ⇒ no workflow, exactly as before). Deterministic and
   synchronous — the convergence core is untouched; the SLM-backed `workflow_suggest`
-  / `harness_learn` passes can still refine the draft. (engine; regression test in
+  / `harness_learn` passes can still refine the draft. (engine; regression tests in
   `tests/engine.test.ts`.)
 - **Configurable workflow-suggestion relevance.** The Jaccard similarity floor and
   result count for surfacing a learned workflow on a new goal are now knobs, not

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The division of labor: **heuristics** generate candidates for free, the **small 
 | `KEYOKU_ENGINE_URL` | — | Connect a running [keyoku-engine](https://github.com/Keyoku-ai/keyoku-engine): knowledge mirrors into it and queries upgrade to semantic search |
 | `KEYOKU_WF_MIN_SIMILARITY` | `0.2` | Jaccard floor for suggesting a learned workflow on a new goal |
 | `KEYOKU_WF_SUGGEST_LIMIT` | `2` | Max learned workflows surfaced per assessment |
+| `KEYOKU_BACKFILL_LOOKBACK_MIN` | `45` | Minutes before a goal's creation to scan for build-then-verify work |
 | `KEYOKU_DEBUG` | — | Full error stacks |
 
 ## Security

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -63,6 +63,11 @@ const WORKFLOW_SUGGESTION_LIMIT = envInt("KEYOKU_WF_SUGGEST_LIMIT", 2);
 // this many inferred steps are lifted from the activity log so the workflow
 // isn't a hollow shell. A bound, not a retention contract.
 const MAX_BACKFILL_STEPS = 30;
+// How far BEFORE a goal was created to look for its work. Build-then-verify
+// often means: do the work, THEN declare the goal and assess once — so the real
+// actions sit just before createdAt. (Real-data check: two converged goals had
+// 2–4s lifetimes because all work preceded goal_create.) A lookback knob.
+const BACKFILL_LOOKBACK_MS = envInt("KEYOKU_BACKFILL_LOOKBACK_MIN", 45) * 60_000;
 
 const MAX_ACTUAL_CHARS = 2_000;
 
@@ -453,7 +458,8 @@ export class Harness {
    * Infer workflow steps for a goal that converged with nothing recorded
    * (build-then-verify). Scope = action events — mutating Bash / Edit / Write /
    * connector calls, never inspection or the harness's own bookkeeping —
-   * observed since the goal was created. Deterministic and synchronous: it lifts
+   * within [createdAt − lookback, convergedAt], narrowed to the dominant session
+   * so concurrent projects don't bleed in. Deterministic and synchronous: it lifts
    * what actually happened from the activity log, it does not decide anything.
    * The log interleaves concurrent sessions, so this is a best-effort draft
    * (labeled source:"activity"), not a verified trace; the SLM-backed
@@ -462,22 +468,49 @@ export class Harness {
    * empty workflows just because the agent didn't call goal_record mid-run.
    */
   private backfillStepsFromActivity(goal: Goal): WorkflowStep[] {
-    const since = Date.parse(goal.createdAt);
-    if (Number.isNaN(since)) return [];
-    const events = this.store.listActivity().filter((e) => {
+    const created = Date.parse(goal.createdAt);
+    if (Number.isNaN(created)) return [];
+    // Window = [createdAt − lookback, convergedAt | now]. The lookback catches
+    // work done just before the goal was declared (build-then-verify); the
+    // upper bound keeps a goal converged in the past from sweeping in later,
+    // unrelated activity.
+    const since = created - BACKFILL_LOOKBACK_MS;
+    const until = goal.convergedAt ? Date.parse(goal.convergedAt) : Date.now();
+    const candidates = this.store.listActivity().filter((e) => {
       const t = Date.parse(e.at);
-      if (Number.isNaN(t) || t < since) return false;
+      if (Number.isNaN(t) || t < since || t > until) return false;
       const tool = e.tool ?? "";
       // The harness's own MCP calls (goal_*, workflow_*, …) are bookkeeping, not
       // the work being learned.
       if (tool.startsWith("mcp__keyoku__") || tool.startsWith("keyoku")) return false;
       return isActionEvent(e);
     });
+    if (candidates.length === 0) return [];
+    // The global log interleaves concurrent sessions — project A's edits sit
+    // next to project B's. Scope to the single session that did the most work in
+    // this window (the build-then-verify stream) so a goal doesn't inherit
+    // another project's actions. Same within-session principle the pattern miner
+    // uses; an SLM pass can refine further. (Real-data check: this is what
+    // stopped a headroom goal from absorbing job-search edits.)
+    const perSession = new Map<string, number>();
+    for (const e of candidates) {
+      const s = e.sessionId ?? "_";
+      perSession.set(s, (perSession.get(s) ?? 0) + 1);
+    }
+    let dominant = "_";
+    let best = -1;
+    for (const [s, n] of perSession) {
+      if (n > best) {
+        best = n;
+        dominant = s;
+      }
+    }
+    const scoped = candidates.filter((e) => (e.sessionId ?? "_") === dominant);
     // Collapse consecutive identical actions (a formatter rewriting one file ten
     // times is one step, not ten), then cap to the most recent steps.
     const steps: WorkflowStep[] = [];
     let lastKey = "";
-    for (const e of events) {
+    for (const e of scoped) {
       const summary = e.summary.slice(0, 200);
       const key = `${e.tool ?? e.type}:${summary}`;
       if (key === lastKey) continue;

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -293,6 +293,43 @@ describe("the convergence loop", () => {
     expect(wf?.steps.every((s) => s.source === "activity")).toBe(true);
   });
 
+  it("backfill looks back before goal creation and scopes to the dominant session", async () => {
+    // The agent did the work, THEN declared + converged the goal (tiny lifetime).
+    const goal = harness.createGoal({
+      objective: "lookback and session scoping",
+      criteria: [
+        {
+          description: "echo ok",
+          probe: { kind: "command", run: "echo ok", parse: "text" },
+          assert: { op: "eq", value: "ok" },
+        },
+      ],
+    });
+    const created = Date.parse(harness.getGoal(goal.slug).createdAt);
+    const at = (deltaMs: number): string => new Date(created + deltaMs).toISOString();
+    let seq = 0;
+    const ev = (over: Partial<ActivityEvent>): ActivityEvent => ({
+      id: `e${seq++}`,
+      type: "tool_use",
+      summary: "x",
+      at: at(0),
+      ...over,
+    });
+    // Pre-goal work in the focus session s1, inside the lookback — MUST be captured:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: src/early.ts", sessionId: "s1", at: at(-5 * 60_000) }));
+    // In-window work, same session — MUST be captured:
+    harness.store.appendActivity(ev({ type: "shell", tool: "Bash", summary: "Bash: npm run build", detail: "npm run build", sessionId: "s1", at: at(-1_000) }));
+    // Concurrent OTHER session — MUST be excluded by session scoping:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: other/project.ts", sessionId: "s2", at: at(-2_000) }));
+    // Before the lookback window — MUST be excluded by time:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: ancient.ts", sessionId: "s1", at: at(-120 * 60_000) }));
+
+    const conv = await harness.assess(goal.slug);
+    expect(conv.converged).toBe(true);
+    const wf = harness.store.getWorkflow(goal.slug);
+    expect(wf?.steps.map((s) => s.summary)).toEqual(["Edit: src/early.ts", "Bash: npm run build"]);
+  });
+
   it("muscle memory is REUSED — a similar goal gets the converged workflow suggested", async () => {
     const stateA = join(dir, "a.txt");
     writeFileSync(stateA, "ready");


### PR DESCRIPTION
## Summary

Follow-up to #42 (activity-backfill). A **read-only proof against the real `~/.keyoku` store** showed the base backfill underdelivered on real goals:

- 2 of 4 hollow goals backfilled **0 steps** — their convergence windows were 2–4s because all work happened *before* `goal_create` (build-then-verify: do the work, then declare + assess once).
- Backfill pulled **cross-project noise** — a `headroom` goal absorbed `job-search-harness` edits from a concurrent session interleaved in the global log.

## Changes

- **Lookback window** — scan `[createdAt − lookback, convergedAt]` instead of `[createdAt → now]`, so work done just before the goal was declared is captured. Tunable via `KEYOKU_BACKFILL_LOOKBACK_MIN` (default 45).
- **Dominant-session scoping** — keep only the session that did the most work in the window, so a goal doesn't inherit a concurrent project's actions. Same within-session principle `detectPatterns` already uses.
- Regression test covering lookback + session scoping; CHANGELOG + README updated.

## Verification

`npm run typecheck` clean · **245/245 tests** · `npm run eval` PASS · `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
