### PR TITLE
feat(backfill): cwd-subtree scoping + head/tail capping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## 2.5.0 — 2026-06-18
+
+- **Backfill attribution + long-build fidelity** (capture lane, follow-up to the
+  v2.2.0 activity-backfill). Two refinements:
+  - **cwd-subtree scoping** on top of the existing dominant-session scoping — one
+    session can touch several projects, so within the dominant session the
+    backfill now keeps only the dominant cwd's subtree (monorepo subdirs stay,
+    sibling projects drop). Events with no cwd are kept (unattributable, not noise).
+  - **Head + tail capping** — instead of keeping only the most recent
+    `MAX_BACKFILL_STEPS`, keep the first `KEYOKU_BACKFILL_HEAD_STEPS` (default 8,
+    the setup) plus the recent tail, with an omission marker between, so a long
+    build doesn't lose how it was set up.
+  Both stay deterministic and synchronous; the convergence core is untouched.
+  Regression tests in `tests/engine.test.ts`.
+
 ## 2.4.0 — 2026-06-18
 
 - **Lite-model re-rank is now ON by default (cached).** Supersedes 2.3.0's opt-in: when a

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The division of labor: **heuristics** generate candidates for free, the **small 
 | `KEYOKU_WF_MIN_SIMILARITY` | `0.2` | Jaccard floor for suggesting a learned workflow on a new goal |
 | `KEYOKU_WF_SUGGEST_LIMIT` | `2` | Max learned workflows surfaced per assessment |
 | `KEYOKU_BACKFILL_LOOKBACK_MIN` | `45` | Minutes before a goal's creation to scan for build-then-verify work |
+| `KEYOKU_BACKFILL_HEAD_STEPS` | `8` | Setup steps kept from the front when a backfilled workflow is capped |
 | `KEYOKU_DEBUG` | — | Full error stacks |
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyoku",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "The harness with muscle memory — watches what you do in Claude Code, Cursor, or Codex, learns your patterns, and turns them into reusable MCP-native workflows.",
   "type": "module",
   "bin": {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -69,6 +69,31 @@ const MAX_BACKFILL_STEPS = 30;
 // actions sit just before createdAt. (Real-data check: two converged goals had
 // 2–4s lifetimes because all work preceded goal_create.) A lookback knob.
 const BACKFILL_LOOKBACK_MS = envInt("KEYOKU_BACKFILL_LOOKBACK_MIN", 45) * 60_000;
+// When more steps are inferred than the cap allows, keep the first HEAD (setup)
+// plus the most recent tail — a long build shouldn't lose how it was set up.
+const BACKFILL_HEAD_STEPS = envInt("KEYOKU_BACKFILL_HEAD_STEPS", 8);
+
+/** Same project subtree: equal, or one is a path-prefix of the other — so
+ * monorepo subdirs stay together while sibling projects don't merge. */
+function sameProject(a: string, b: string): boolean {
+  return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`);
+}
+
+/** Cap a step list keeping the first `head` (setup) and the most recent
+ * `max - head` (build/verify); a marker records the omission so the draft stays
+ * honest about the gap. Lists at or under `max` pass through unchanged. */
+function capHeadTail(steps: WorkflowStep[], max: number, head: number): WorkflowStep[] {
+  if (steps.length <= max) return steps;
+  const h = Math.max(0, Math.min(head, max - 1));
+  const tail = steps.slice(-(max - h));
+  const omitted = steps.length - h - tail.length;
+  const marker: WorkflowStep = {
+    summary: `… ${omitted} intermediate step${omitted === 1 ? "" : "s"} omitted …`,
+    result: "success",
+    source: "activity",
+  };
+  return [...steps.slice(0, h), marker, ...tail];
+}
 
 const MAX_ACTUAL_CHARS = 2_000;
 
@@ -471,7 +496,8 @@ export class Harness {
    * (build-then-verify). Scope = action events — mutating Bash / Edit / Write /
    * connector calls, never inspection or the harness's own bookkeeping —
    * within [createdAt − lookback, convergedAt], narrowed to the dominant session
-   * so concurrent projects don't bleed in. Deterministic and synchronous: it lifts
+   * and cwd-subtree so concurrent projects don't bleed in, then capped head+tail
+   * so a long build keeps its setup. Deterministic and synchronous: it lifts
    * what actually happened from the activity log, it does not decide anything.
    * The log interleaves concurrent sessions, so this is a best-effort draft
    * (labeled source:"activity"), not a verified trace; the SLM-backed
@@ -517,7 +543,27 @@ export class Harness {
         dominant = s;
       }
     }
-    const scoped = candidates.filter((e) => (e.sessionId ?? "_") === dominant);
+    let scoped = candidates.filter((e) => (e.sessionId ?? "_") === dominant);
+    // Within that session, narrow to the dominant cwd-subtree for precise
+    // attribution — one session can touch several projects. Events without a cwd
+    // are kept: we can't attribute them, and dropping them would lose real work.
+    const withCwd = scoped.filter((e) => e.cwd);
+    if (withCwd.length > 0) {
+      const perCwd = new Map<string, number>();
+      for (const e of withCwd) {
+        const c = e.cwd as string;
+        perCwd.set(c, (perCwd.get(c) ?? 0) + 1);
+      }
+      let domCwd = "";
+      let bestCwd = -1;
+      for (const [c, n] of perCwd) {
+        if (n > bestCwd) {
+          bestCwd = n;
+          domCwd = c;
+        }
+      }
+      scoped = scoped.filter((e) => !e.cwd || sameProject(e.cwd, domCwd));
+    }
     // Collapse consecutive identical actions (a formatter rewriting one file ten
     // times is one step, not ten), then cap to the most recent steps.
     const steps: WorkflowStep[] = [];
@@ -534,7 +580,7 @@ export class Harness {
         source: "activity" as const,
       });
     }
-    return steps.slice(-MAX_BACKFILL_STEPS);
+    return capHeadTail(steps, MAX_BACKFILL_STEPS, BACKFILL_HEAD_STEPS);
   }
 
   suggestWorkflows(goal: Goal): WorkflowSuggestion[] {

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -331,6 +331,77 @@ describe("the convergence loop", () => {
     expect(wf?.steps.map((s) => s.summary)).toEqual(["Edit: src/early.ts", "Bash: npm run build"]);
   });
 
+  it("backfill scopes to the dominant cwd-subtree within the session", async () => {
+    const goal = harness.createGoal({
+      objective: "cwd scoping",
+      criteria: [
+        {
+          description: "echo ok",
+          probe: { kind: "command", run: "echo ok", parse: "text" },
+          assert: { op: "eq", value: "ok" },
+        },
+      ],
+    });
+    const created = Date.parse(harness.getGoal(goal.slug).createdAt);
+    const at = (deltaMs: number): string => new Date(created + deltaMs).toISOString();
+    let seq = 0;
+    const ev = (over: Partial<ActivityEvent>): ActivityEvent => ({
+      id: `e${seq++}`,
+      type: "tool_use",
+      summary: "x",
+      at: at(-1_000),
+      sessionId: "s1",
+      ...over,
+    });
+    // Dominant project /proj-a (2 events) + a subdir of it — all MUST be kept:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: a1.ts", cwd: "/proj-a", at: at(-5_000) }));
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: a2.ts", cwd: "/proj-a", at: at(-4_000) }));
+    harness.store.appendActivity(ev({ type: "shell", tool: "Bash", summary: "Bash: build a", detail: "make", cwd: "/proj-a/sub", at: at(-3_000) }));
+    // Sibling project /proj-b — MUST be dropped:
+    harness.store.appendActivity(ev({ type: "file_change", tool: "Edit", summary: "Edit: b1.ts", cwd: "/proj-b", at: at(-2_000) }));
+    // No cwd — unattributable, MUST be kept:
+    harness.store.appendActivity(ev({ type: "shell", tool: "Bash", summary: "Bash: no cwd step", detail: "node deploy.js", at: at(-1_500) }));
+
+    const conv = await harness.assess(goal.slug);
+    expect(conv.converged).toBe(true);
+    const summaries = harness.store.getWorkflow(goal.slug)?.steps.map((s) => s.summary) ?? [];
+    expect(summaries).toEqual(["Edit: a1.ts", "Edit: a2.ts", "Bash: build a", "Bash: no cwd step"]);
+    expect(summaries).not.toContain("Edit: b1.ts");
+  });
+
+  it("backfill keeps first-N setup steps and the recent tail when capped", async () => {
+    const goal = harness.createGoal({
+      objective: "head tail cap",
+      criteria: [
+        {
+          description: "echo ok",
+          probe: { kind: "command", run: "echo ok", parse: "text" },
+          assert: { op: "eq", value: "ok" },
+        },
+      ],
+    });
+    const created = Date.parse(harness.getGoal(goal.slug).createdAt);
+    for (let i = 0; i < 50; i++) {
+      harness.store.appendActivity({
+        id: `e${i}`,
+        type: "shell",
+        tool: "Bash",
+        summary: `Bash: step ${String(i).padStart(2, "0")}`,
+        detail: `cmd ${i}`,
+        sessionId: "s1",
+        at: new Date(created - (50 - i) * 1_000).toISOString(),
+      });
+    }
+    const conv = await harness.assess(goal.slug);
+    expect(conv.converged).toBe(true);
+    const steps = harness.store.getWorkflow(goal.slug)?.steps ?? [];
+    expect(steps.length).toBe(31); // 30 cap + 1 omission marker
+    expect(steps[0].summary).toBe("Bash: step 00"); // setup preserved
+    expect(steps[7].summary).toBe("Bash: step 07");
+    expect(steps.some((s) => /omitted/.test(s.summary))).toBe(true);
+    expect(steps[steps.length - 1].summary).toBe("Bash: step 49"); // recent tail
+  });
+
   it("muscle memory is REUSED — a similar goal gets the converged workflow suggested", async () => {
     const stateA = join(dir, "a.txt");
     writeFileSync(stateA, "ready");


### PR DESCRIPTION
## Summary

Two capture-lane follow-ups Tye flagged, rebased on `main` (2.3.0), building on the v2.2.0 activity-backfill + #43 session scoping. Stays out of retrieval/learning/evals.

## Changes

1. **cwd-subtree scoping** (attribution precision) — within the dominant session, keep only the dominant cwd's subtree. Monorepo subdirs stay together (`/proj/a` + `/proj/a/sub`); sibling projects drop (`/proj/b`). Events with **no** cwd are kept — unattributable, not noise. Layers on top of the existing dominant-session scoping.
2. **Head + tail capping** — a long build no longer loses its setup. Instead of keeping only the last `MAX_BACKFILL_STEPS`, keep the first `KEYOKU_BACKFILL_HEAD_STEPS` (default 8) **plus** the recent tail, with a `… N intermediate steps omitted …` marker between.

Both deterministic + synchronous; convergence core untouched.

## Verification

`npm run typecheck` clean · **248/248 tests** (2 new backfill tests) · `npm run eval` PASS · `npm run build` succeeds.

## Lane

Capture/backfill only — no changes to `suggestWorkflows`, retrieval, or evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
