### PR TITLE
feat: replayable learned steps + focus session-pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Replayable muscle memory — learned steps carry the command** (capture lane).
+  `WorkflowStep` gained `detail`, and both the backfill and the recorded/live
+  paths now carry the action's actual command into the learned step instead of
+  dropping it. A learned workflow used to read "Bash: npm run build" (a
+  description); it now also carries `"npm run build"` (the thing to run), so the
+  step is **replayable**, and the command flows into the structured
+  `suggestedWorkflows` an agent receives.
+- **Focus session-pinning — concurrency hardening** (capture lane). Live capture
+  (`goal_focus`) now treats the session as authoritative once known: the first
+  matching action **pins** the focus to that session, and later events from a
+  different session are rejected even if they share the project dir. This stops a
+  second session working in the same project on one shared `~/.keyoku` from
+  bleeding its actions into another goal's trace.
+  Regression tests in `tests/engine.test.ts`.
+
 ## 2.6.0 — 2026-06-18
 
 - **Live muscle memory — `goal_focus` + auto-record** (capture lane). Until now a

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -478,6 +478,7 @@ export class Harness {
       .map((r) => ({
         summary: r.summary,
         ...(r.tool ? { tool: r.tool } : {}),
+        ...(r.detail ? { detail: r.detail } : {}),
         result: r.result,
         ...(r.source ? { source: r.source } : {}),
       }));
@@ -618,6 +619,7 @@ export class Harness {
       steps.push({
         summary,
         ...(e.tool ? { tool: e.tool } : {}),
+        ...(e.detail ? { detail: e.detail.slice(0, 500) } : {}),
         result: "success" as const,
         source: "activity" as const,
       });
@@ -722,15 +724,19 @@ export function autoRecordToFocusGoal(store: Store, event: ActivityEvent): void 
     const tool = event.tool ?? "";
     if (tool.startsWith("mcp__keyoku__") || tool.startsWith("keyoku")) return;
     if (!isActionEvent(event)) return;
-    // Attribution: prefer an exact session match; else require the event's cwd
-    // to sit in the focus cwd-subtree. An unscoped focus (no cwd/session)
-    // accepts everything — best-effort.
-    const sessionMatch = focus.sessionId !== undefined && event.sessionId === focus.sessionId;
+    // Attribution gate. Session is authoritative when known on both sides: if
+    // the focus is pinned to a session and this event came from a different one,
+    // it's another session's work — reject it even if the cwd matches. Otherwise
+    // fall back to cwd-subtree; a fully unscoped focus accepts everything.
+    const focusSession = focus.sessionId;
+    const evSession = event.sessionId;
+    if (focusSession !== undefined && evSession !== undefined && focusSession !== evSession) return;
+    const sessionMatch = focusSession !== undefined && evSession === focusSession;
     const a = event.cwd;
     const b = focus.cwd;
     const cwdMatch =
       b !== undefined && a !== undefined && (a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`));
-    const unscoped = focus.sessionId === undefined && focus.cwd === undefined;
+    const unscoped = focusSession === undefined && focus.cwd === undefined;
     if (!sessionMatch && !cwdMatch && !unscoped) return;
     const goal = store.getGoal(focus.goalId);
     if (!goal || goal.status !== "active") return; // never live-record to a non-active goal
@@ -740,6 +746,12 @@ export function autoRecordToFocusGoal(store: Store, event: ActivityEvent): void 
     const recs = store.listRecords(goal.id);
     const last = recs[recs.length - 1];
     if (last && last.summary === summary && last.tool === event.tool) return;
+    // Pin the session on the first matching action: once a session has done real
+    // work toward this focused goal, later events must match it — so a second
+    // session in the same project can't start writing into this goal's trace.
+    if (focusSession === undefined && evSession !== undefined) {
+      store.setFocus({ ...focus, sessionId: evSession });
+    }
     store.appendRecord({
       id: newId("act"),
       goalId: goal.id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,6 +259,9 @@ export interface FocusState {
 export interface WorkflowStep {
   summary: string;
   tool?: string;
+  /** The actual command / args that ran (truncated), so a learned workflow is
+   *  replayable, not just a description. Carried from the action's detail. */
+  detail?: string;
   result: ActionResult;
   /** Provenance: "recorded" = an explicit goal_record corrective action;
    *  "activity" = inferred from the activity log because the goal converged

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -292,6 +292,8 @@ describe("the convergence loop", () => {
     expect(wf).toBeTruthy();
     expect(wf?.steps.map((s) => s.summary)).toEqual(["Edit: src/server.ts", "Bash: npm run build"]);
     expect(wf?.steps.every((s) => s.source === "activity")).toBe(true);
+    // The actual command is carried so the learned step is replayable, not just described.
+    expect(wf?.steps.find((s) => s.tool === "Bash")?.detail).toBe("npm run build");
   });
 
   it("backfill looks back before goal creation and scopes to the dominant session", async () => {
@@ -686,6 +688,33 @@ describe("live capture (goal_focus + auto-record)", () => {
     expect(wf?.steps.map((s) => s.summary)).toEqual(["Bash: build"]);
     expect(wf?.steps.every((s) => s.source === "activity")).toBe(true);
     expect(harness.getFocus()).toBeNull(); // cleared on convergence
+  });
+
+  it("learned steps carry the command (detail) so the workflow is replayable", async () => {
+    const goal = harness.createGoal(echoGoal("replayable"));
+    harness.setFocus(goal.slug, { cwd: "/p" });
+    autoRecordToFocusGoal(
+      harness.store,
+      ev({ type: "shell", tool: "Bash", summary: "Bash: deploy", detail: "./deploy.sh --prod", cwd: "/p" }),
+    );
+    const conv = await harness.assess(goal.slug);
+    expect(conv.converged).toBe(true);
+    const wf = harness.store.getWorkflow(goal.slug);
+    expect(wf?.steps[0].summary).toBe("Bash: deploy");
+    expect(wf?.steps[0].detail).toBe("./deploy.sh --prod"); // the actual command, replayable
+  });
+
+  it("pins the session on first action so a concurrent same-project session can't contaminate", () => {
+    const goal = harness.createGoal(echoGoal("pinning"));
+    harness.setFocus(goal.slug, { cwd: "/p" }); // cwd-only focus, session unknown
+    // s1 does the first matching action → recorded AND focus pins to s1
+    autoRecordToFocusGoal(harness.store, ev({ type: "file_change", tool: "Edit", summary: "Edit: s1.ts", cwd: "/p", sessionId: "s1" }));
+    expect(harness.getFocus()?.sessionId).toBe("s1");
+    // s2, same project, different session → rejected now that focus is pinned
+    autoRecordToFocusGoal(harness.store, ev({ type: "file_change", tool: "Edit", summary: "Edit: s2.ts", cwd: "/p", sessionId: "s2" }));
+    // s1 again → still captured
+    autoRecordToFocusGoal(harness.store, ev({ type: "shell", tool: "Bash", summary: "Bash: t", detail: "make", cwd: "/p", sessionId: "s1" }));
+    expect(harness.store.listRecords(goal.id).map((r) => r.summary)).toEqual(["Edit: s1.ts", "Bash: t"]);
   });
 
   it("refuses to focus a non-active goal", () => {


### PR DESCRIPTION
## Summary

Closes the two capture-lane gaps from the post-audit review.

### #1 — replayable learned steps
Learned `WorkflowStep` kept only `summary`, so the actual command in `ActionRecord.detail` / `event.detail` was **dropped** — a learned workflow read *"Bash: npm run build"* (a description) but lost *"npm run build"* (the thing to run). Now `WorkflowStep` carries `detail`, and both `promoteWorkflow` (recorded + live paths) and the activity backfill propagate it. The command flows into the structured `suggestedWorkflows` an agent receives, so muscle memory is **replayable**, not just descriptive. (Guidance *presentation* left untouched — retrieval lane.)

### #4 — focus session-pinning (concurrency hardening)
Live capture (`goal_focus`) now treats the session as authoritative once known: the **first matching action pins** the focus to that session, and later events from a different session are rejected even if they share the project dir. Stops a second same-project session on one shared `~/.keyoku` from bleeding into another goal's trace.

## Verification
`npm run typecheck` clean · **254/254 tests** (3 new: backfill detail, replayable detail, session-pinning) · `npm run eval` PASS · `npm run build` succeeds.

## Lane
Capture lane only — no changes to `suggestWorkflows`/retrieval/evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
